### PR TITLE
fix: include_str broken in certain build configurations

### DIFF
--- a/formatting/src/lib.rs
+++ b/formatting/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../../README.md")]
+#![doc = include_str!(concat!("../", env!("CARGO_PKG_README")))]
 #![no_std]
 
 #[macro_use]


### PR DESCRIPTION
This should fix the document build so that it works both with `cargo doc` and `cargo publish`, at least it does locally for me. I think this should fix the docs on docs.rs as well.